### PR TITLE
chore: Change `linkml` dependency to a branch at a fork temporarily

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: CPython",
 ]
 dependencies = [
-  "linkml~=1.8",
+  "linkml @ git+https://github.com/candleindark/linkml.git@bundle-error",
   "pydantic~=2.7",
   "typer",
 ]
@@ -42,6 +42,9 @@ pydantic2linkml = "pydantic2linkml.cli:app"
 
 [tool.hatch.version]
 path = "src/pydantic2linkml/__about__.py"
+
+[tool.hatch.metadata]
+allow-direct-references = true
 
 [tool.hatch.envs.default]
 python = "3.9"


### PR DESCRIPTION
We need the approved changes at @candleindark's fork. This change in dependency should only last until https://github.com/linkml/linkml/pull/2363 is included in a new LinkML version.