### PR TITLE
Pin Pydantic dependency to below 2.10 and remove test associated with `aind_data_schema`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
 ]
 dependencies = [
   "linkml @ git+https://github.com/candleindark/linkml.git@bundle-error",
-  "pydantic~=2.7",
+  "pydantic>=2.7,<2.10",
   "typer",
 ]
 

--- a/tests/test_gen_linkml.py
+++ b/tests/test_gen_linkml.py
@@ -119,24 +119,35 @@ class TestLinkmlGenerator:
         "models_and_enums",
         [
             ["dandischema.models"],
-            ["aind_data_schema.components.coordinates"],
+            # === Remove all tests associated with aind_data_schema until works for
+            # dandischema is complete ===
+            pytest.param(
+                ["aind_data_schema.components.coordinates"], marks=pytest.mark.xfail
+            ),
             # Naming conflict at this one
-            # TODO: remove xfail mark once handling of the naming conflict is devised
             pytest.param(
                 ["aind_data_schema.components.devices"], marks=pytest.mark.xfail
             ),
-            ["aind_data_schema.components.reagent"],
-            ["aind_data_schema.components.stimulus"],
-            ["aind_data_schema.components.tile"],
-            ["aind_data_schema.core.acquisition"],
-            ["aind_data_schema.core.data_description"],
-            ["aind_data_schema.core.instrument"],
-            ["aind_data_schema.core.metadata"],
-            ["aind_data_schema.core.procedures"],
-            ["aind_data_schema.core.processing"],
-            ["aind_data_schema.core.rig"],
-            ["aind_data_schema.core.session"],
-            ["aind_data_schema.core.subject"],
+            pytest.param(
+                ["aind_data_schema.components.reagent"], marks=pytest.mark.xfail
+            ),
+            pytest.param(
+                ["aind_data_schema.components.stimulus"], marks=pytest.mark.xfail
+            ),
+            pytest.param(["aind_data_schema.components.tile"], marks=pytest.mark.xfail),
+            pytest.param(
+                ["aind_data_schema.core.acquisition"], marks=pytest.mark.xfail
+            ),
+            pytest.param(
+                ["aind_data_schema.core.data_description"], marks=pytest.mark.xfail
+            ),
+            pytest.param(["aind_data_schema.core.instrument"], marks=pytest.mark.xfail),
+            pytest.param(["aind_data_schema.core.metadata"], marks=pytest.mark.xfail),
+            pytest.param(["aind_data_schema.core.procedures"], marks=pytest.mark.xfail),
+            pytest.param(["aind_data_schema.core.processing"], marks=pytest.mark.xfail),
+            pytest.param(["aind_data_schema.core.rig"], marks=pytest.mark.xfail),
+            pytest.param(["aind_data_schema.core.session"], marks=pytest.mark.xfail),
+            pytest.param(["aind_data_schema.core.subject"], marks=pytest.mark.xfail),
             # TODO: Add test cases with list containing multiple module names
         ],
         indirect=True,


### PR DESCRIPTION
This PR pins Pydantic dependency to below 2.10 and removes test associated with `aind_data_schema`.

Pydanic 2.10 support will be added via #10, and `aind_data_schema` support will not be added until `dandischema` support is more complete.

Note: The support for `aind_data_schema` is remove because version changes introduces new elements needed for translation.